### PR TITLE
Remove System.Locale import to solve defaultTimeLocale ambiguity

### DIFF
--- a/web-server/Main.hs
+++ b/web-server/Main.hs
@@ -28,7 +28,6 @@ import Network.HTTP.Stream
 import Network.Stream
 import System.Exit
 import System.Info
-import System.Locale
 import Text.Blaze.Html5 as H hiding (map)
 import Text.Blaze.Html5.Attributes(href)
 import Text.Blaze.Html.Renderer.String

--- a/web-server/Main.hs
+++ b/web-server/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE CPP #-}
 -- Copyright 2014 Galois, Inc.
 -- This software is distributed under a standard, three-clause BSD license.
 -- Please see the file LICENSE, distributed with this software, for specific
@@ -32,6 +33,10 @@ import Text.Blaze.Html5 as H hiding (map)
 import Text.Blaze.Html5.Attributes(href)
 import Text.Blaze.Html.Renderer.String
 import Text.Blaze.Internal(string)
+
+#if !MIN_VERSION_base(4,8,0)
+import           System.Locale
+#endif
 
 instance Stream Socket where
   readLine s = loop ""


### PR DESCRIPTION
I was getting this error on base-4.8 (GHC 7.10):

    web-server/Main.hs:72:34:
        Ambiguous occurrence ‘defaultTimeLocale’
        It could refer to either ‘Data.Time.defaultTimeLocale’,
                                 imported from ‘Data.Time’ at web-server/Main.hs:14:1-16
                                 (and originally defined in ‘time-1.5.0.1:Data.Time.Format.Locale’)
                              or ‘System.Locale.defaultTimeLocale’,
                                 imported from ‘System.Locale’ at web-server/Main.hs:31:1-20