### PR TITLE
Bound the time wait heap.

### DIFF
--- a/src/Hans/Config.hs
+++ b/src/Hans/Config.hs
@@ -67,6 +67,10 @@ data Config = Config { cfgInputQueueSize :: !Int
                        -- ^ Frequency (in Hz) of timestamp clock updates.
                        -- Should be between 1Hz and 1000Hz, according to
                        -- RFC-1323.
+
+                     , cfgTcpTimeWaitSocketLimit :: !Int
+                       -- ^ The max number of threads allowed in the time
+                       -- wait heap.
                      }
 
 defaultConfig :: Config
@@ -88,6 +92,7 @@ defaultConfig  = Config { cfgInputQueueSize     = 128
                         , cfgTcpInitialWindow   = 14600
                         , cfgTcpMSL             = 60 -- one minute
                         , cfgTcpTSClockFrequency = 1000 -- 1000hz, update every 1ms
+                        , cfgTcpTimeWaitSocketLimit = 70
                         }
 
 class HasConfig cfg where

--- a/src/Hans/Tcp/State.hs
+++ b/src/Hans/Tcp/State.hs
@@ -218,7 +218,7 @@ registerTimeWait state tcb =
           let heap' = if H.size heap >= cfgTcpTimeWaitSocketLimit
                          then H.deleteMin heap
                          else heap
-           in fst (expireAt (addUTCTime cfgTcpTimeoutTimeWait now) tcb heap)
+           in fst (expireAt (addUTCTime cfgTcpTimeoutTimeWait now) tcb heap')
 
 -- | Reset the timer associated with a TimeWaitTcb.
 resetTimeWait :: (HasConfig state, HasTcpState state)

--- a/src/Hans/Tcp/State.hs
+++ b/src/Hans/Tcp/State.hs
@@ -53,6 +53,7 @@ import           Data.ByteArray (withByteArray)
 import qualified Data.ByteString as S
 import qualified Data.Foldable as F
 import           Data.Hashable (Hashable)
+import qualified Data.Heap as H
 import           Data.IORef (IORef,newIORef,atomicModifyIORef',readIORef)
 import           Data.Serialize (runPut,putByteString)
 import           Data.Time.Clock (UTCTime,getCurrentTime,addUTCTime,diffUTCTime)
@@ -214,7 +215,10 @@ registerTimeWait :: (HasConfig state, HasTcpState state)
 registerTimeWait state tcb =
   let Config { .. } = view config state
    in updateTimeWait state $ \ now heap ->
-          fst (expireAt (addUTCTime cfgTcpTimeoutTimeWait now) tcb heap)
+          let heap' = if H.size heap >= cfgTcpTimeWaitSocketLimit
+                         then H.deleteMin heap
+                         else heap
+           in fst (expireAt (addUTCTime cfgTcpTimeoutTimeWait now) tcb heap)
 
 -- | Reset the timer associated with a TimeWaitTcb.
 resetTimeWait :: (HasConfig state, HasTcpState state)


### PR DESCRIPTION
To avoid growing a large heap and eating up memory.

@elliottt is this what you imagined? (and more?)