### PR TITLE
Idle timer reset

### DIFF
--- a/src/Hans/Tcp/Input.hs
+++ b/src/Hans/Tcp/Input.hs
@@ -183,6 +183,9 @@ handleActiveSegs ns tcb now = go
        -- check ACK
        unless (view tcpAck hdr) continue
 
+       -- Reset idle timeout
+       io $ atomicModifyIORef' (tcbTimers tcb) resetIdleTimer
+
        -- update the send window
        mbAck <- io $
          do mbAck <- atomicModifyIORef' (tcbSendWindow tcb)

--- a/src/Hans/Tcp/Tcb.hs
+++ b/src/Hans/Tcp/Tcb.hs
@@ -46,6 +46,7 @@ module Hans.Tcp.Tcb (
     setRcvNxt,
     finalizeTcb,
     getSndUna,
+    resetIdleTimer,
 
     -- ** Active Config
     TcbConfig(..),
@@ -171,6 +172,12 @@ updateTimers tt = (tt',tt)
            , ttIdle       = ttIdle tt + 1
            }
 
+-- | Reset idle timer in the presence of packets, for use with
+-- 'atomicModifyIORef\''.
+resetIdleTimer :: TcpTimers -> (TcpTimers, ())
+resetIdleTimer t = (idleReset, ())
+  where
+   idleReset = t { ttIdle = 0 }
 
 -- | Calibrate the RTO timer, given a round-trip measurement, as specified by
 -- RFC-6298.


### PR DESCRIPTION
Idle timer should be reset in the presence of packets for an active connection